### PR TITLE
Update rnmapbox/maps broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is no longer actively maintained. 
 
-Continued development of react-native-mapbox-gl may be found in the community driven repository at [https://github.com/react-native-mapbox-gl/maps](https://github.com/react-native-mapbox-gl/maps). This new repository uses the latest versions of the Mapbox SDKs for iOS and Android, and contains a long range of improvements over the current one. We recommend you review the [changelog](https://github.com/react-native-mapbox-gl/maps/blob/master/CHANGELOG.md) for the new repository and transition to it.
+Continued development of react-native-mapbox-gl may be found in the community driven repository at [https://github.com/rnmapbox/maps](https://github.com/rnmapbox/maps). This new repository uses the latest versions of the Mapbox SDKs for iOS and Android, and contains a long range of improvements over the current one. We recommend you review the [changelog](https://github.com/rnmapbox/maps/blob/main/CHANGELOG.md) for the new repository and transition to it.
 
 This repository will _only_ accept PRs containing bug fixes. Any new feature development will happen in the new repository.
 


### PR DESCRIPTION
The outdated link for this repository is still shown on the React Native directory:
https://reactnative.directory/?search=mapbox

This PR fixes the broken link to the new community repository which supports Mapbox SDKs v10.
https://github.com/rnmapbox/maps